### PR TITLE
Add KubeCluster integration to example notebooks and command line tools

### DIFF
--- a/HPO/9_23_2019_dataGen_hpoParticleSwarm.ipynb
+++ b/HPO/9_23_2019_dataGen_hpoParticleSwarm.ipynb
@@ -104,7 +104,7 @@
     {
      "data": {
       "text/plain": [
-       "<module 'rapids_lib_v10' from '/rapids/notebooks/rapids/HPO/rapids_lib_v10.py'>"
+       "<module 'rapids_lib_v10' from '/root/jupyterlab-nvdashboard/rapids/HPO/rapids_lib_v10.py'>"
       ]
      },
      "execution_count": 7,
@@ -231,14 +231,14 @@
      "text": [
       "generating blobs; # points = 400000\n",
       "generating blobs; # points = 400000\n",
-      "time to generate data on GPU = 1.2980446815490723\n",
+      "time to generate data on GPU = 1.751633644104004\n",
       "\t plotting data - stride = 8 \n"
      ]
     },
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "969e8cfb648d47f89ebc4bbabe828982",
+       "model_id": "25ff508956bb4b71a0f089044341b060",
        "version_major": 2,
        "version_minor": 0
       },
@@ -270,14 +270,14 @@
      "text": [
       "generating blobs; # points = 400000\n",
       "generating blobs; # points = 400000\n",
-      "time to generate data on GPU = 0.27510929107666016\n",
+      "time to generate data on GPU = 0.3305344581604004\n",
       "\t plotting data - stride = 8 \n"
      ]
     },
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "f03dc5e7d8424dcfa2757d9a92488e68",
+       "model_id": "0e820ffccd2a488981eeb527a2df5809",
        "version_major": 2,
        "version_minor": 0
       },
@@ -365,9 +365,9 @@
       "splitting data into training and test set\n",
       "rescaling data\n",
       "rescaling data\n",
-      " + adding log entry [ CPU_split_train_test     :   0.06159 s ]\n",
-      " + adding log entry [ CPU_scale_train_data     :   0.08877 s ]\n",
-      " + adding log entry [ CPU_scale_test_data      :   0.05375 s ]\n"
+      " + adding log entry [ CPU_split_train_test     :   0.06097 s ]\n",
+      " + adding log entry [ CPU_scale_train_data     :   0.09096 s ]\n",
+      " + adding log entry [ CPU_scale_test_data      :   0.05746 s ]\n"
      ]
     }
    ],
@@ -403,9 +403,9 @@
       "splitting data into training and test set\n",
       "rescaling data\n",
       "rescaling data\n",
-      " + adding log entry [ GPU_split_train_test     :   0.23715 s ]\n",
-      " + adding log entry [ GPU_scale_train_data     :   0.00680 s ]\n",
-      " + adding log entry [ GPU_scale_test_data      :   0.00401 s ]\n"
+      " + adding log entry [ GPU_split_train_test     :   0.25170 s ]\n",
+      " + adding log entry [ GPU_scale_train_data     :   0.00655 s ]\n",
+      " + adding log entry [ GPU_scale_test_data      :   0.00384 s ]\n"
      ]
     }
    ],
@@ -452,7 +452,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "dd0b7125ccc44845ba0f72a60d8a5b10",
+       "model_id": "c72dd97ebe1e49648b83859635373037",
        "version_major": 2,
        "version_minor": 0
       },
@@ -616,8 +616,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " + adding log entry [ CPU_model_training       :   4.07688 s ]\n",
-      " + adding log entry [ CPU_model_inference      :   0.02410 s ]\n"
+      " + adding log entry [ CPU_model_training       :  11.27392 s ]\n",
+      " + adding log entry [ CPU_model_inference      :   0.03098 s ]\n"
      ]
     }
    ],
@@ -675,8 +675,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " + adding log entry [ GPU_model_training       :   0.33588 s ]\n",
-      " + adding log entry [ GPU_model_inference      :   0.01609 s ]\n"
+      " + adding log entry [ GPU_model_training       :   0.33834 s ]\n",
+      " + adding log entry [ GPU_model_inference      :   0.01222 s ]\n"
      ]
     }
    ],
@@ -761,8 +761,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 56.7 ms, sys: 25.7 ms, total: 82.4 ms\n",
-      "Wall time: 188 ms\n"
+      "CPU times: user 58.3 ms, sys: 32.3 ms, total: 90.6 ms\n",
+      "Wall time: 203 ms\n"
      ]
     },
     {
@@ -792,16 +792,16 @@
     {
      "data": {
       "text/plain": [
-       "{'CPU_split_train_test': 0.061591386795043945,\n",
-       " 'CPU_scale_train_data': 0.08876633644104004,\n",
-       " 'CPU_scale_test_data': 0.05375027656555176,\n",
-       " 'GPU_split_train_test': 0.23714780807495117,\n",
-       " 'GPU_scale_train_data': 0.006800174713134766,\n",
-       " 'GPU_scale_test_data': 0.004008054733276367,\n",
-       " 'CPU_model_training': 4.07687783241272,\n",
-       " 'CPU_model_inference': 0.02409839630126953,\n",
-       " 'GPU_model_training': 0.3358757495880127,\n",
-       " 'GPU_model_inference': 0.016091346740722656}"
+       "{'CPU_split_train_test': 0.06097245216369629,\n",
+       " 'CPU_scale_train_data': 0.0909569263458252,\n",
+       " 'CPU_scale_test_data': 0.057457923889160156,\n",
+       " 'GPU_split_train_test': 0.2516958713531494,\n",
+       " 'GPU_scale_train_data': 0.0065460205078125,\n",
+       " 'GPU_scale_test_data': 0.0038383007049560547,\n",
+       " 'CPU_model_training': 11.273921728134155,\n",
+       " 'CPU_model_inference': 0.03097987174987793,\n",
+       " 'GPU_model_training': 0.3383357524871826,\n",
+       " 'GPU_model_inference': 0.01221776008605957}"
       ]
      },
      "execution_count": 31,
@@ -834,15 +834,26 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import dask\n",
-    "from dask import delayed\n",
-    "from dask_cuda import LocalCUDACluster\n",
-    "from dask.distributed import Client"
+    "dask_type = \"k8s\""
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 33,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import dask\n",
+    "from dask import delayed\n",
+    "from dask_cuda import LocalCUDACluster\n",
+    "from dask_kubernetes import KubeCluster\n",
+    "from dask.distributed import Client\n",
+    "from time import sleep # We need to give K8S some time to manually scale workers"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
    "metadata": {},
    "outputs": [
     {
@@ -862,22 +873,87 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Set number of workers [ changes require kernel restart ]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 34,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "cluster = LocalCUDACluster(ip=\"\", n_workers = 4 )\n",
-    "client = Client(cluster)"
+    "#### Define the Kubernetes Dask Spec"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 35,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "worker_spec_fname = '/worker_spec.yaml'\n",
+    "worker_spec = '''\n",
+    "# worker-spec.yml\n",
+    "\n",
+    "kind: Pod\n",
+    "metadata:\n",
+    "  labels:\n",
+    "    foo: bar\n",
+    "spec:\n",
+    "  restartPolicy: Never\n",
+    "  containers:\n",
+    "  - image: supertetelman/k8s-rapids-dask:0.9-cuda10.0-runtime-ubuntu18.04\n",
+    "    imagePullPolicy: IfNotPresent\n",
+    "    args: [dask-worker,  --nthreads, '1', --no-bokeh, --memory-limit, 6GB, --no-bokeh, --death-timeout, '60']\n",
+    "    name: dask\n",
+    "    resources:\n",
+    "      limits:\n",
+    "        cpu: \"2\"\n",
+    "        memory: 6G\n",
+    "        nvidia.com/gpu: 1\n",
+    "      requests:\n",
+    "        cpu: \"2\"\n",
+    "        memory: 6G\n",
+    "        nvidia.com/gpu: 1\n",
+    "'''\n",
+    "\n",
+    "with open(worker_spec_fname, \"w\") as yaml_file:\n",
+    "    yaml_file.write(worker_spec)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 61,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def scale_k8s_cluster(cluster, n, m=None):\n",
+    "    if dask_type != \"k8s\":\n",
+    "        print(\"Cannot scale non-K8S cluster\")\n",
+    "        return\n",
+    "    if m is None:\n",
+    "        cluster.scale(n)\n",
+    "    else:\n",
+    "        cluster.adapt(n, m)\n",
+    "    sleep(10)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Set number of workers [ changes require kernel restart ]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 62,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if dask_type == \"k8s\":\n",
+    "    cluster = KubeCluster.from_yaml(worker_spec_fname)\n",
+    "    cluster.scale(4)\n",
+    "else:\n",
+    "    cluster = LocalCUDACluster(ip=\"\", n_workers = 4 )\n",
+    "\n",
+    "client = Client(cluster)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 63,
    "metadata": {},
    "outputs": [
     {
@@ -888,26 +964,26 @@
        "<td style=\"vertical-align: top; border: 0px solid white\">\n",
        "<h3 style=\"text-align: left;\">Client</h3>\n",
        "<ul style=\"text-align: left; list-style: none; margin: 0; padding: 0;\">\n",
-       "  <li><b>Scheduler: </b>tcp://172.17.0.2:40343</li>\n",
-       "  <li><b>Dashboard: </b><a href='http://172.17.0.2:8787/status' target='_blank'>http://172.17.0.2:8787/status</a>\n",
+       "  <li><b>Scheduler: </b>tcp://10.233.69.185:36217</li>\n",
+       "  <li><b>Dashboard: </b><a href='http://10.233.69.185:33341/status' target='_blank'>http://10.233.69.185:33341/status</a>\n",
        "</ul>\n",
        "</td>\n",
        "<td style=\"vertical-align: top; border: 0px solid white\">\n",
        "<h3 style=\"text-align: left;\">Cluster</h3>\n",
        "<ul style=\"text-align: left; list-style:none; margin: 0; padding: 0;\">\n",
-       "  <li><b>Workers: </b>4</li>\n",
-       "  <li><b>Cores: </b>4</li>\n",
-       "  <li><b>Memory: </b>270.39 GB</li>\n",
+       "  <li><b>Workers: </b>0</li>\n",
+       "  <li><b>Cores: </b>0</li>\n",
+       "  <li><b>Memory: </b>0 B</li>\n",
        "</ul>\n",
        "</td>\n",
        "</tr>\n",
        "</table>"
       ],
       "text/plain": [
-       "<Client: scheduler='tcp://172.17.0.2:40343' processes=4 cores=4>"
+       "<Client: scheduler='tcp://10.233.69.185:36217' processes=0 cores=0>"
       ]
      },
-     "execution_count": 35,
+     "execution_count": 63,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -918,18 +994,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 64,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "a52b2cd58d864ed188b5a01e7a22a894",
+       "model_id": "b99d666e089647ed82d6a69ab887ce7e",
        "version_major": 2,
        "version_minor": 0
       },
       "text/plain": [
-       "VBox(children=(HTML(value='<h2>LocalCUDACluster</h2>'), HBox(children=(HTML(value='\\n<div>\\n  <style scoped>\\n…"
+       "VBox(children=(HTML(value='<h2>KubeCluster</h2>'), HBox(children=(HTML(value='\\n<div>\\n  <style scoped>\\n    .…"
       ]
      },
      "metadata": {},
@@ -949,7 +1025,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": 65,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -959,17 +1035,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": 66,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "[<Future: status: finished, type: DataFrame, key: DataFrame-a32756310531973ddc29c58d3c5de420>,\n",
-       " <Future: status: finished, type: DataFrame, key: DataFrame-60f5330d23a5a1747be062b5c2c20164>]"
+       "[<Future: status: finished, type: DataFrame, key: DataFrame-d84b79409d28ba98944f7756bed5e2c4>,\n",
+       " <Future: status: finished, type: DataFrame, key: DataFrame-de45c5271c414175b99e351917f8dc63>]"
       ]
      },
-     "execution_count": 38,
+     "execution_count": 66,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -980,32 +1056,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": 67,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "DataFrame-a32756310531973ddc29c58d3c5de420 \n",
-      " DataFrame-60f5330d23a5a1747be062b5c2c20164 \n",
+      "DataFrame-d84b79409d28ba98944f7756bed5e2c4 \n",
+      " DataFrame-de45c5271c414175b99e351917f8dc63 \n",
       "\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "{'DataFrame-a32756310531973ddc29c58d3c5de420': ('tcp://172.17.0.2:37547',\n",
-       "  'tcp://172.17.0.2:44957',\n",
-       "  'tcp://172.17.0.2:42379',\n",
-       "  'tcp://172.17.0.2:36019'),\n",
-       " 'DataFrame-60f5330d23a5a1747be062b5c2c20164': ('tcp://172.17.0.2:37547',\n",
-       "  'tcp://172.17.0.2:44957',\n",
-       "  'tcp://172.17.0.2:42379',\n",
-       "  'tcp://172.17.0.2:36019')}"
+       "{'DataFrame-d84b79409d28ba98944f7756bed5e2c4': ('tcp://10.233.69.253:46505',),\n",
+       " 'DataFrame-de45c5271c414175b99e351917f8dc63': ('tcp://10.233.69.253:46505',)}"
       ]
      },
-     "execution_count": 39,
+     "execution_count": 67,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1024,7 +1094,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": 68,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1066,7 +1136,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": 69,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1109,7 +1179,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": 70,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1220,17 +1290,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": 71,
    "metadata": {},
    "outputs": [],
    "source": [
     "nTimesteps = 10\n",
-    "nParticles = 16"
+    "nParticles = 32"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": 72,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1248,13 +1318,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 73,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "scale_k8s_cluster(cluster, 1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 74,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "948d13ea7c244cfd91e0c474acf34ac6",
+       "model_id": "c29c9d300f3f4f9c830f07419bcf7a45",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1269,19 +1348,193 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "@ hpo timestep : 0, best accuracy is 0.9471625\n",
+      "@ hpo timestep : 0, best accuracy is 0.9512125\n",
       "\t updating best GLOBAL accuracy\n",
-      "@ hpo timestep : 1, best accuracy is 0.951475\n",
+      "@ hpo timestep : 1, best accuracy is 0.9527\n",
       "\t updating best GLOBAL accuracy\n",
-      "@ hpo timestep : 2, best accuracy is 0.951475\n",
-      "@ hpo timestep : 3, best accuracy is 0.94875\n",
-      "@ hpo timestep : 4, best accuracy is 0.9498875\n",
-      "@ hpo timestep : 5, best accuracy is 0.94875\n",
-      "@ hpo timestep : 6, best accuracy is 0.951475\n",
-      "@ hpo timestep : 7, best accuracy is 0.9494125\n"
+      "@ hpo timestep : 2, best accuracy is 0.9515125\n",
+      "@ hpo timestep : 3, best accuracy is 0.9505625\n",
+      "@ hpo timestep : 4, best accuracy is 0.9514\n",
+      "@ hpo timestep : 5, best accuracy is 0.951525\n",
+      "@ hpo timestep : 6, best accuracy is 0.952725\n",
+      "\t updating best GLOBAL accuracy\n",
+      "@ hpo timestep : 7, best accuracy is 0.9510125\n",
+      "@ hpo timestep : 8, best accuracy is 0.9502375\n",
+      "@ hpo timestep : 9, best accuracy is 0.9502375\n",
+      "highest accuracy               :  0.952725 \n",
+      "   @ timestep 6, particle 17 \n",
+      "\n",
+      "best model tree depth          :  5.0 \n",
+      "best model learning rate       :  0.8335521669442962 \n",
+      "best model regularization      :  0.11902468106903752 \n",
+      "best model num boosting rounds :  49 \n",
+      "elapsed time : 201.4471321105957\n"
      ]
     }
    ],
+   "source": [
+    "accuracies, particles, velocities, particleSizes, particleColors, bestParticleIndex, \\\n",
+    "bestParamIndex, particleBoostingRounds, trainingTimes, predictionHistory, elapsedTime = run_hpo ( client, nTimesteps, \n",
+    "                                                                                                  nParticles,\n",
+    "                                                                                                  paramRanges, \n",
+    "                                                                                                  trainData_cDF, trainLabels_cDF, testData_cDF, testLabels_cDF )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 75,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "scale_k8s_cluster(cluster, 2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 76,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "1851154858954504aeaf692de7f154d8",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(Figure(camera=PerspectiveCamera(fov=46.0, position=(0.0, 0.0, 2.0), quaternion=(0.0, 0.0, 0.0, …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "@ hpo timestep : 0, best accuracy is 0.9512125\n",
+      "\t updating best GLOBAL accuracy\n",
+      "@ hpo timestep : 1, best accuracy is 0.9527\n",
+      "\t updating best GLOBAL accuracy\n",
+      "@ hpo timestep : 2, best accuracy is 0.9515125\n",
+      "@ hpo timestep : 3, best accuracy is 0.9505625\n",
+      "@ hpo timestep : 4, best accuracy is 0.9514\n",
+      "@ hpo timestep : 5, best accuracy is 0.951525\n",
+      "@ hpo timestep : 6, best accuracy is 0.952725\n",
+      "\t updating best GLOBAL accuracy\n",
+      "@ hpo timestep : 7, best accuracy is 0.9510125\n",
+      "@ hpo timestep : 8, best accuracy is 0.9502375\n",
+      "@ hpo timestep : 9, best accuracy is 0.9502375\n",
+      "highest accuracy               :  0.952725 \n",
+      "   @ timestep 6, particle 17 \n",
+      "\n",
+      "best model tree depth          :  5.0 \n",
+      "best model learning rate       :  0.8335521669442962 \n",
+      "best model regularization      :  0.11902468106903752 \n",
+      "best model num boosting rounds :  49 \n",
+      "elapsed time : 106.28980898857117\n"
+     ]
+    }
+   ],
+   "source": [
+    "accuracies, particles, velocities, particleSizes, particleColors, bestParticleIndex, \\\n",
+    "bestParamIndex, particleBoostingRounds, trainingTimes, predictionHistory, elapsedTime = run_hpo ( client, nTimesteps, \n",
+    "                                                                                                  nParticles,\n",
+    "                                                                                                  paramRanges, \n",
+    "                                                                                                  trainData_cDF, trainLabels_cDF, testData_cDF, testLabels_cDF )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 77,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "scale_k8s_cluster(cluster, 4)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 78,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "4b3a5890d2964ec9a0f149991f33662c",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "VBox(children=(Figure(camera=PerspectiveCamera(fov=46.0, position=(0.0, 0.0, 2.0), quaternion=(0.0, 0.0, 0.0, …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "@ hpo timestep : 0, best accuracy is 0.9512125\n",
+      "\t updating best GLOBAL accuracy\n",
+      "@ hpo timestep : 1, best accuracy is 0.9527\n",
+      "\t updating best GLOBAL accuracy\n",
+      "@ hpo timestep : 2, best accuracy is 0.9515125\n",
+      "@ hpo timestep : 3, best accuracy is 0.9505625\n",
+      "@ hpo timestep : 4, best accuracy is 0.9514\n",
+      "@ hpo timestep : 5, best accuracy is 0.951525\n",
+      "@ hpo timestep : 6, best accuracy is 0.952725\n",
+      "\t updating best GLOBAL accuracy\n",
+      "@ hpo timestep : 7, best accuracy is 0.9510125\n",
+      "@ hpo timestep : 8, best accuracy is 0.9502375\n",
+      "@ hpo timestep : 9, best accuracy is 0.9502375\n",
+      "highest accuracy               :  0.952725 \n",
+      "   @ timestep 6, particle 17 \n",
+      "\n",
+      "best model tree depth          :  5.0 \n",
+      "best model learning rate       :  0.8335521669442962 \n",
+      "best model regularization      :  0.11902468106903752 \n",
+      "best model num boosting rounds :  49 \n",
+      "elapsed time : 76.79185676574707\n"
+     ]
+    }
+   ],
+   "source": [
+    "accuracies, particles, velocities, particleSizes, particleColors, bestParticleIndex, \\\n",
+    "bestParamIndex, particleBoostingRounds, trainingTimes, predictionHistory, elapsedTime = run_hpo ( client, nTimesteps, \n",
+    "                                                                                                  nParticles,\n",
+    "                                                                                                  paramRanges, \n",
+    "                                                                                                  trainData_cDF, trainLabels_cDF, testData_cDF, testLabels_cDF )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 79,
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "TypeError",
+     "evalue": "adapt() takes from 1 to 2 positional arguments but 3 were given",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mTypeError\u001b[0m                                 Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-79-93799a30c96a>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0mscale_k8s_cluster\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mcluster\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;36m0\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;36m4\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[0;32m<ipython-input-61-40c4bb2060b7>\u001b[0m in \u001b[0;36mscale_k8s_cluster\u001b[0;34m(cluster, n, m)\u001b[0m\n\u001b[1;32m      6\u001b[0m         \u001b[0mcluster\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mscale\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mn\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      7\u001b[0m     \u001b[0;32melse\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 8\u001b[0;31m         \u001b[0mcluster\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0madapt\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mn\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mm\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      9\u001b[0m     \u001b[0msleep\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;36m10\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mTypeError\u001b[0m: adapt() takes from 1 to 2 positional arguments but 3 were given"
+     ]
+    }
+   ],
+   "source": [
+    "scale_k8s_cluster(cluster, 0, 4)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "accuracies, particles, velocities, particleSizes, particleColors, bestParticleIndex, \\\n",
     "bestParamIndex, particleBoostingRounds, trainingTimes, predictionHistory, elapsedTime = run_hpo ( client, nTimesteps, \n",
@@ -1340,7 +1593,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 56,
    "metadata": {},
    "outputs": [],
    "source": [

--- a/HPO/9_23_2019_dataGen_hpoParticleSwarm.ipynb
+++ b/HPO/9_23_2019_dataGen_hpoParticleSwarm.ipynb
@@ -231,14 +231,14 @@
      "text": [
       "generating blobs; # points = 400000\n",
       "generating blobs; # points = 400000\n",
-      "time to generate data on GPU = 1.751633644104004\n",
+      "time to generate data on GPU = 1.5238211154937744\n",
       "\t plotting data - stride = 8 \n"
      ]
     },
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "25ff508956bb4b71a0f089044341b060",
+       "model_id": "572587d0f67b401ea622df3d036324f9",
        "version_major": 2,
        "version_minor": 0
       },
@@ -270,14 +270,14 @@
      "text": [
       "generating blobs; # points = 400000\n",
       "generating blobs; # points = 400000\n",
-      "time to generate data on GPU = 0.3305344581604004\n",
+      "time to generate data on GPU = 0.30245304107666016\n",
       "\t plotting data - stride = 8 \n"
      ]
     },
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "0e820ffccd2a488981eeb527a2df5809",
+       "model_id": "874484269d864068b0208ef73ee8ea7b",
        "version_major": 2,
        "version_minor": 0
       },
@@ -365,9 +365,9 @@
       "splitting data into training and test set\n",
       "rescaling data\n",
       "rescaling data\n",
-      " + adding log entry [ CPU_split_train_test     :   0.06097 s ]\n",
-      " + adding log entry [ CPU_scale_train_data     :   0.09096 s ]\n",
-      " + adding log entry [ CPU_scale_test_data      :   0.05746 s ]\n"
+      " + adding log entry [ CPU_split_train_test     :   0.06382 s ]\n",
+      " + adding log entry [ CPU_scale_train_data     :   0.09367 s ]\n",
+      " + adding log entry [ CPU_scale_test_data      :   0.05882 s ]\n"
      ]
     }
    ],
@@ -403,9 +403,9 @@
       "splitting data into training and test set\n",
       "rescaling data\n",
       "rescaling data\n",
-      " + adding log entry [ GPU_split_train_test     :   0.25170 s ]\n",
-      " + adding log entry [ GPU_scale_train_data     :   0.00655 s ]\n",
-      " + adding log entry [ GPU_scale_test_data      :   0.00384 s ]\n"
+      " + adding log entry [ GPU_split_train_test     :   0.27913 s ]\n",
+      " + adding log entry [ GPU_scale_train_data     :   0.00662 s ]\n",
+      " + adding log entry [ GPU_scale_test_data      :   0.00374 s ]\n"
      ]
     }
    ],
@@ -452,7 +452,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "c72dd97ebe1e49648b83859635373037",
+       "model_id": "f9648d30627946e5ac48efb1f47b108b",
        "version_major": 2,
        "version_minor": 0
       },
@@ -616,8 +616,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " + adding log entry [ CPU_model_training       :  11.27392 s ]\n",
-      " + adding log entry [ CPU_model_inference      :   0.03098 s ]\n"
+      " + adding log entry [ CPU_model_training       :  11.67323 s ]\n",
+      " + adding log entry [ CPU_model_inference      :   0.02761 s ]\n"
      ]
     }
    ],
@@ -675,8 +675,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " + adding log entry [ GPU_model_training       :   0.33834 s ]\n",
-      " + adding log entry [ GPU_model_inference      :   0.01222 s ]\n"
+      " + adding log entry [ GPU_model_training       :   0.32612 s ]\n",
+      " + adding log entry [ GPU_model_inference      :   0.01234 s ]\n"
      ]
     }
    ],
@@ -761,8 +761,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 58.3 ms, sys: 32.3 ms, total: 90.6 ms\n",
-      "Wall time: 203 ms\n"
+      "CPU times: user 63.7 ms, sys: 64.3 ms, total: 128 ms\n",
+      "Wall time: 232 ms\n"
      ]
     },
     {
@@ -792,16 +792,16 @@
     {
      "data": {
       "text/plain": [
-       "{'CPU_split_train_test': 0.06097245216369629,\n",
-       " 'CPU_scale_train_data': 0.0909569263458252,\n",
-       " 'CPU_scale_test_data': 0.057457923889160156,\n",
-       " 'GPU_split_train_test': 0.2516958713531494,\n",
-       " 'GPU_scale_train_data': 0.0065460205078125,\n",
-       " 'GPU_scale_test_data': 0.0038383007049560547,\n",
-       " 'CPU_model_training': 11.273921728134155,\n",
-       " 'CPU_model_inference': 0.03097987174987793,\n",
-       " 'GPU_model_training': 0.3383357524871826,\n",
-       " 'GPU_model_inference': 0.01221776008605957}"
+       "{'CPU_split_train_test': 0.06382083892822266,\n",
+       " 'CPU_scale_train_data': 0.0936739444732666,\n",
+       " 'CPU_scale_test_data': 0.058820486068725586,\n",
+       " 'GPU_split_train_test': 0.2791256904602051,\n",
+       " 'GPU_scale_train_data': 0.006623983383178711,\n",
+       " 'GPU_scale_test_data': 0.0037429332733154297,\n",
+       " 'CPU_model_training': 11.673229932785034,\n",
+       " 'CPU_model_inference': 0.027606487274169922,\n",
+       " 'GPU_model_training': 0.3261239528656006,\n",
+       " 'GPU_model_inference': 0.012343645095825195}"
       ]
      },
      "execution_count": 31,
@@ -895,7 +895,7 @@
     "  containers:\n",
     "  - image: supertetelman/k8s-rapids-dask:0.9-cuda10.0-runtime-ubuntu18.04\n",
     "    imagePullPolicy: IfNotPresent\n",
-    "    args: [dask-worker,  --nthreads, '1', --no-bokeh, --memory-limit, 6GB, --no-bokeh, --death-timeout, '60']\n",
+    "    args: [dask-worker,  --nthreads, '1', --no-bokeh, --memory-limit, 6GB, --death-timeout, '60']\n",
     "    name: dask\n",
     "    resources:\n",
     "      limits:\n",
@@ -914,18 +914,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 61,
+   "execution_count": 36,
    "metadata": {},
    "outputs": [],
    "source": [
-    "def scale_k8s_cluster(cluster, n, m=None):\n",
+    "def scale_cluster(cluster, n, m=None):\n",
     "    if dask_type != \"k8s\":\n",
     "        print(\"Cannot scale non-K8S cluster\")\n",
     "        return\n",
     "    if m is None:\n",
+    "        print(f'Scaling to {n} nodes')\n",
     "        cluster.scale(n)\n",
     "    else:\n",
-    "        cluster.adapt(n, m)\n",
+    "        print(f'Setting Scaling to adapatve, [{n}, {m}]')\n",
+    "        cluster.adapt(minimum = n, maximum = m)\n",
     "    sleep(10)"
    ]
   },
@@ -938,22 +940,41 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 62,
+   "execution_count": 37,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/opt/conda/envs/rapids/lib/python3.6/site-packages/distributed/dashboard/core.py:72: UserWarning: \n",
+      "Port 8787 is already in use. \n",
+      "Perhaps you already have a cluster running?\n",
+      "Hosting the diagnostics dashboard on a random port instead.\n",
+      "  warnings.warn(\"\\n\" + msg)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Scaling to 4 nodes\n"
+     ]
+    }
+   ],
    "source": [
     "if dask_type == \"k8s\":\n",
     "    cluster = KubeCluster.from_yaml(worker_spec_fname)\n",
-    "    cluster.scale(4)\n",
+    "    scale_cluster(cluster, 4)\n",
     "else:\n",
-    "    cluster = LocalCUDACluster(ip=\"\", n_workers = 4 )\n",
+    "    cluster = LocalCUDACluster(ip=\"\", n_workers = 4)\n",
     "\n",
     "client = Client(cluster)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 63,
+   "execution_count": 38,
    "metadata": {},
    "outputs": [
     {
@@ -964,26 +985,26 @@
        "<td style=\"vertical-align: top; border: 0px solid white\">\n",
        "<h3 style=\"text-align: left;\">Client</h3>\n",
        "<ul style=\"text-align: left; list-style: none; margin: 0; padding: 0;\">\n",
-       "  <li><b>Scheduler: </b>tcp://10.233.69.185:36217</li>\n",
-       "  <li><b>Dashboard: </b><a href='http://10.233.69.185:33341/status' target='_blank'>http://10.233.69.185:33341/status</a>\n",
+       "  <li><b>Scheduler: </b>tcp://10.233.69.185:46667</li>\n",
+       "  <li><b>Dashboard: </b><a href='http://10.233.69.185:45537/status' target='_blank'>http://10.233.69.185:45537/status</a>\n",
        "</ul>\n",
        "</td>\n",
        "<td style=\"vertical-align: top; border: 0px solid white\">\n",
        "<h3 style=\"text-align: left;\">Cluster</h3>\n",
        "<ul style=\"text-align: left; list-style:none; margin: 0; padding: 0;\">\n",
-       "  <li><b>Workers: </b>0</li>\n",
-       "  <li><b>Cores: </b>0</li>\n",
-       "  <li><b>Memory: </b>0 B</li>\n",
+       "  <li><b>Workers: </b>4</li>\n",
+       "  <li><b>Cores: </b>4</li>\n",
+       "  <li><b>Memory: </b>24.00 GB</li>\n",
        "</ul>\n",
        "</td>\n",
        "</tr>\n",
        "</table>"
       ],
       "text/plain": [
-       "<Client: scheduler='tcp://10.233.69.185:36217' processes=0 cores=0>"
+       "<Client: scheduler='tcp://10.233.69.185:46667' processes=4 cores=4>"
       ]
      },
-     "execution_count": 63,
+     "execution_count": 38,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -994,13 +1015,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 64,
+   "execution_count": 39,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "b99d666e089647ed82d6a69ab887ce7e",
+       "model_id": "357b410c6c194883a199bdaab1b5edf9",
        "version_major": 2,
        "version_minor": 0
       },
@@ -1025,7 +1046,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 65,
+   "execution_count": 40,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1035,17 +1056,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 66,
+   "execution_count": 41,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "[<Future: status: finished, type: DataFrame, key: DataFrame-d84b79409d28ba98944f7756bed5e2c4>,\n",
-       " <Future: status: finished, type: DataFrame, key: DataFrame-de45c5271c414175b99e351917f8dc63>]"
+       "[<Future: status: finished, type: DataFrame, key: DataFrame-cc40d87ed31d76c9ebb9c294724ef266>,\n",
+       " <Future: status: finished, type: DataFrame, key: DataFrame-c2e8c35d0cd1da47a3e49af424c2791d>]"
       ]
      },
-     "execution_count": 66,
+     "execution_count": 41,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1056,26 +1077,32 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 67,
+   "execution_count": 42,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "DataFrame-d84b79409d28ba98944f7756bed5e2c4 \n",
-      " DataFrame-de45c5271c414175b99e351917f8dc63 \n",
+      "DataFrame-cc40d87ed31d76c9ebb9c294724ef266 \n",
+      " DataFrame-c2e8c35d0cd1da47a3e49af424c2791d \n",
       "\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "{'DataFrame-d84b79409d28ba98944f7756bed5e2c4': ('tcp://10.233.69.253:46505',),\n",
-       " 'DataFrame-de45c5271c414175b99e351917f8dc63': ('tcp://10.233.69.253:46505',)}"
+       "{'DataFrame-c2e8c35d0cd1da47a3e49af424c2791d': ('tcp://10.233.69.130:46121',\n",
+       "  'tcp://10.233.69.135:36101',\n",
+       "  'tcp://10.233.69.131:41493',\n",
+       "  'tcp://10.233.69.138:37747'),\n",
+       " 'DataFrame-cc40d87ed31d76c9ebb9c294724ef266': ('tcp://10.233.69.130:46121',\n",
+       "  'tcp://10.233.69.135:36101',\n",
+       "  'tcp://10.233.69.131:41493',\n",
+       "  'tcp://10.233.69.138:37747')}"
       ]
      },
-     "execution_count": 67,
+     "execution_count": 42,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1094,7 +1121,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 68,
+   "execution_count": 43,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1136,7 +1163,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 69,
+   "execution_count": 44,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1179,7 +1206,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 70,
+   "execution_count": 45,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1290,7 +1317,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 71,
+   "execution_count": 46,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1300,7 +1327,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 72,
+   "execution_count": 47,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1318,36 +1345,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 73,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "scale_k8s_cluster(cluster, 1)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 74,
+   "execution_count": 48,
    "metadata": {},
    "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "c29c9d300f3f4f9c830f07419bcf7a45",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "VBox(children=(Figure(camera=PerspectiveCamera(fov=46.0, position=(0.0, 0.0, 2.0), quaternion=(0.0, 0.0, 0.0, …"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "Scaling to 1 nodes\n",
       "@ hpo timestep : 0, best accuracy is 0.9512125\n",
       "\t updating best GLOBAL accuracy\n",
       "@ hpo timestep : 1, best accuracy is 0.9527\n",
@@ -1368,50 +1373,8 @@
       "best model learning rate       :  0.8335521669442962 \n",
       "best model regularization      :  0.11902468106903752 \n",
       "best model num boosting rounds :  49 \n",
-      "elapsed time : 201.4471321105957\n"
-     ]
-    }
-   ],
-   "source": [
-    "accuracies, particles, velocities, particleSizes, particleColors, bestParticleIndex, \\\n",
-    "bestParamIndex, particleBoostingRounds, trainingTimes, predictionHistory, elapsedTime = run_hpo ( client, nTimesteps, \n",
-    "                                                                                                  nParticles,\n",
-    "                                                                                                  paramRanges, \n",
-    "                                                                                                  trainData_cDF, trainLabels_cDF, testData_cDF, testLabels_cDF )"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 75,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "scale_k8s_cluster(cluster, 2)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 76,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "1851154858954504aeaf692de7f154d8",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "VBox(children=(Figure(camera=PerspectiveCamera(fov=46.0, position=(0.0, 0.0, 2.0), quaternion=(0.0, 0.0, 0.0, …"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "elapsed time : 338.15017795562744\n",
+      "Scaling to 2 nodes\n",
       "@ hpo timestep : 0, best accuracy is 0.9512125\n",
       "\t updating best GLOBAL accuracy\n",
       "@ hpo timestep : 1, best accuracy is 0.9527\n",
@@ -1432,50 +1395,8 @@
       "best model learning rate       :  0.8335521669442962 \n",
       "best model regularization      :  0.11902468106903752 \n",
       "best model num boosting rounds :  49 \n",
-      "elapsed time : 106.28980898857117\n"
-     ]
-    }
-   ],
-   "source": [
-    "accuracies, particles, velocities, particleSizes, particleColors, bestParticleIndex, \\\n",
-    "bestParamIndex, particleBoostingRounds, trainingTimes, predictionHistory, elapsedTime = run_hpo ( client, nTimesteps, \n",
-    "                                                                                                  nParticles,\n",
-    "                                                                                                  paramRanges, \n",
-    "                                                                                                  trainData_cDF, trainLabels_cDF, testData_cDF, testLabels_cDF )"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 77,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "scale_k8s_cluster(cluster, 4)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 78,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "4b3a5890d2964ec9a0f149991f33662c",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "VBox(children=(Figure(camera=PerspectiveCamera(fov=46.0, position=(0.0, 0.0, 2.0), quaternion=(0.0, 0.0, 0.0, …"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "elapsed time : 372.158490896225\n",
+      "Setting Scaling to adapatve, [0, 4]\n",
       "@ hpo timestep : 0, best accuracy is 0.9512125\n",
       "\t updating best GLOBAL accuracy\n",
       "@ hpo timestep : 1, best accuracy is 0.9527\n",
@@ -1496,38 +1417,44 @@
       "best model learning rate       :  0.8335521669442962 \n",
       "best model regularization      :  0.11902468106903752 \n",
       "best model num boosting rounds :  49 \n",
-      "elapsed time : 76.79185676574707\n"
+      "elapsed time : 338.94904136657715\n",
+      "Scaling to 0 nodes\n"
      ]
     }
    ],
    "source": [
-    "accuracies, particles, velocities, particleSizes, particleColors, bestParticleIndex, \\\n",
-    "bestParamIndex, particleBoostingRounds, trainingTimes, predictionHistory, elapsedTime = run_hpo ( client, nTimesteps, \n",
-    "                                                                                                  nParticles,\n",
-    "                                                                                                  paramRanges, \n",
-    "                                                                                                  trainData_cDF, trainLabels_cDF, testData_cDF, testLabels_cDF )"
+    "# Kubernetes let's us dynamically scale the cluster size, which allows us to do these benchmarks\n",
+    "if dask_type == \"k8s\":\n",
+    "    scale_cluster(cluster, 1)\n",
+    "    run_hpo ( client, nTimesteps, nParticles, paramRanges, trainData_cDF,\n",
+    "              trainLabels_cDF, testData_cDF, testLabels_cDF, plotFlag=False )\n",
+    "    \n",
+    "    scale_cluster(cluster, 2)\n",
+    "    run_hpo ( client, nTimesteps, nParticles, paramRanges, trainData_cDF,\n",
+    "              trainLabels_cDF, testData_cDF, testLabels_cDF, plotFlag=False )\n",
+    "    \n",
+    "    scale_cluster(cluster, 0, 4)\n",
+    "    run_hpo ( client, nTimesteps, nParticles, paramRanges, trainData_cDF,\n",
+    "              trainLabels_cDF, testData_cDF, testLabels_cDF, plotFlag=False )\n",
+    "    \n",
+    "    scale_cluster(cluster, 0)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 79,
+   "execution_count": 49,
    "metadata": {},
    "outputs": [
     {
-     "ename": "TypeError",
-     "evalue": "adapt() takes from 1 to 2 positional arguments but 3 were given",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mTypeError\u001b[0m                                 Traceback (most recent call last)",
-      "\u001b[0;32m<ipython-input-79-93799a30c96a>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0mscale_k8s_cluster\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mcluster\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;36m0\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;36m4\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
-      "\u001b[0;32m<ipython-input-61-40c4bb2060b7>\u001b[0m in \u001b[0;36mscale_k8s_cluster\u001b[0;34m(cluster, n, m)\u001b[0m\n\u001b[1;32m      6\u001b[0m         \u001b[0mcluster\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mscale\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mn\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      7\u001b[0m     \u001b[0;32melse\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 8\u001b[0;31m         \u001b[0mcluster\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0madapt\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mn\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mm\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      9\u001b[0m     \u001b[0msleep\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;36m10\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;31mTypeError\u001b[0m: adapt() takes from 1 to 2 positional arguments but 3 were given"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Scaling to 4 nodes\n"
      ]
     }
    ],
    "source": [
-    "scale_k8s_cluster(cluster, 0, 4)"
+    "scale_cluster(cluster, 4)"
    ]
   },
   {
@@ -1588,12 +1515,21 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Appendix"
+    "## Appendix\n",
+    "##### Jupyter Extensions\n",
+    "* [Dask Extension](https://github.com/dask/dask-labextension)\n",
+    "* [NVIDIA System Dashboard](https://github.com/jacobtomlinson/jupyterlab-nvdashboard/blob/master/README.md)\n",
+    "\n",
+    "##### Dask Kubernetes\n",
+    "* [Example Notebook](https://github.com/supertetelman/k8s-rapids-dask/blob/master/k8s_examples/Scaling%20Dask%20in%20Kubernetes.ipynb)\n",
+    "* [Docker Image](https://github.com/supertetelman/k8s-rapids-dask/blob/master/Dockerfile)\n",
+    "* [K8S/Kubeflow/Dask Deployment Guide](https://github.com/NVIDIA/deepops/blob/master/docs/kubernetes-cluster.md)\n",
+    "* [Official Docs](https://kubernetes.dask.org/en/latest/)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 56,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [

--- a/HPO/Dockerfile
+++ b/HPO/Dockerfile
@@ -12,6 +12,8 @@ RUN source activate rapids && conda install -c conda-forge python-graphviz
 
 RUN source activate rapids && conda install -y -c rapidsai cupy
 
+RUN source activate rapids && pip install git+https://github.com/dask/dask-kubernetes.git
+
 RUN source activate rapids && git clone https://github.com/miroenev/rapids && cd rapids/HPO/ && python setup.py install
 
 EXPOSE 8888

--- a/HPO/Dockerfile
+++ b/HPO/Dockerfile
@@ -12,7 +12,7 @@ RUN source activate rapids && conda install -c conda-forge python-graphviz
 
 RUN source activate rapids && conda install -y -c rapidsai cupy
 
-RUN git clone https://github.com/miroenev/rapids
+RUN source activate rapids && git clone https://github.com/miroenev/rapids && cd rapids/HPO/ && python setup.py install
 
 EXPOSE 8888
 

--- a/HPO/command_line.ipynb
+++ b/HPO/command_line.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [
     {
@@ -12,8 +12,10 @@
       "usage: main.py [-h] [--coil_type COIL_TYPE] [--num_blobs NUM_BLOBS]\n",
       "               [--num_coordinates NUM_COORDINATES] [--sdev_scale SDEV_SCALE]\n",
       "               [--noise_scale NOISE_SCALE] [--coil_density COIL_DENSITY]\n",
-      "               [--train_test_overlap TRAIN_TEST_OVERLAP] [--num_gpus NUM_GPUS]\n",
-      "               [--num_timesteps NUM_TIMESTEPS]\n",
+      "               [--train_test_overlap TRAIN_TEST_OVERLAP]\n",
+      "               [--num_timesteps NUM_TIMESTEPS] [--num_particles NUM_PARTICLES]\n",
+      "               [--k8s] [--adapt] [--spec SPEC] [--num_gpus NUM_GPUS]\n",
+      "               [--min_gpus MIN_GPUS]\n",
       "\n",
       "Perform hyper-parameter optimization using Dask\n",
       "\n",
@@ -37,9 +39,20 @@
       "  --train_test_overlap TRAIN_TEST_OVERLAP\n",
       "                        percentage of train and test distribution that\n",
       "                        overlaps (default: 0.05)\n",
-      "  --num_gpus NUM_GPUS   the number of gpus to use (default: 1)\n",
       "  --num_timesteps NUM_TIMESTEPS\n",
-      "                        the number of timesteps to run HPO (default: 10)\n"
+      "                        the number of timesteps to run HPO (default: 10)\n",
+      "  --num_particles NUM_PARTICLES\n",
+      "                        the number of particles in the swarm (default: 32)\n",
+      "  --k8s                 use a KubeCluster instead of LocalCudaCluster\n",
+      "                        (default: False)\n",
+      "  --adapt               use adaptive scaling of k8s workers [min_gpus,\n",
+      "                        num_gpus] (default: False)\n",
+      "  --spec SPEC           the k8s worker_spec yaml file to use (default: None)\n",
+      "  --num_gpus NUM_GPUS   the number of workers deployed or maximum workers when\n",
+      "                        using K8S adaptive; each worker gets 1 GPU (default:\n",
+      "                        1)\n",
+      "  --min_gpus MIN_GPUS   the minimum number of workers when using adaptive\n",
+      "                        scaling (default: 32)\n"
      ]
     }
    ],
@@ -49,43 +62,48 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Launching Dask cluster with 4 GPUs\n",
-      "<Client: scheduler='tcp://192.168.99.2:40907' processes=4 cores=4>\n",
+      "/opt/conda/envs/rapids/lib/python3.6/site-packages/distributed/dashboard/core.py:72: UserWarning: \n",
+      "Port 8787 is already in use. \n",
+      "Perhaps you already have a cluster running?\n",
+      "Hosting the diagnostics dashboard on a random port instead.\n",
+      "  warnings.warn(\"\\n\" + msg)\n",
+      "Launching Local Dask cluster with 4 GPUs\n",
+      "<Client: scheduler='tcp://10.233.69.185:43317' processes=4 cores=4>\n",
+      "LocalCUDACluster('tcp://10.233.69.185:43317', workers=4, nthreads=4)\n",
       "generating blobs; # points = 400000\n",
       "generating blobs; # points = 400000\n",
-      "time to generate data on GPU = 1.1876380443572998\n",
+      "time to generate data on GPU = 1.7928249835968018\n",
       "splitting data into training and test set\n",
       "rescaling data\n",
       "rescaling data\n",
-      "@ hpo timestep : 0, best accuracy is 0.9477\n",
+      "@ hpo timestep : 0, best accuracy is 0.9512125\n",
       "\t updating best GLOBAL accuracy\n",
-      "@ hpo timestep : 1, best accuracy is 0.9516625\n",
+      "@ hpo timestep : 1, best accuracy is 0.9527\n",
       "\t updating best GLOBAL accuracy\n",
-      "@ hpo timestep : 2, best accuracy is 0.9520625\n",
+      "@ hpo timestep : 2, best accuracy is 0.9515125\n",
+      "@ hpo timestep : 3, best accuracy is 0.94855\n",
+      "@ hpo timestep : 4, best accuracy is 0.951225\n",
+      "@ hpo timestep : 5, best accuracy is 0.951975\n",
+      "@ hpo timestep : 6, best accuracy is 0.952725\n",
       "\t updating best GLOBAL accuracy\n",
-      "@ hpo timestep : 3, best accuracy is 0.9498375\n",
-      "@ hpo timestep : 4, best accuracy is 0.9516625\n",
-      "@ hpo timestep : 5, best accuracy is 0.50445\n",
-      "@ hpo timestep : 6, best accuracy is 0.9516625\n",
-      "@ hpo timestep : 7, best accuracy is 0.9545\n",
-      "\t updating best GLOBAL accuracy\n",
-      "@ hpo timestep : 8, best accuracy is 0.9520625\n",
-      "@ hpo timestep : 9, best accuracy is 0.9515375\n",
-      "highest accuracy               :  0.9545 \n",
-      "   @ timestep 7, particle 21 \n",
+      "@ hpo timestep : 7, best accuracy is 0.9510125\n",
+      "@ hpo timestep : 8, best accuracy is 0.9502375\n",
+      "@ hpo timestep : 9, best accuracy is 0.9502375\n",
+      "highest accuracy               :  0.952725 \n",
+      "   @ timestep 6, particle 17 \n",
       "\n",
-      "best model tree depth          :  6.0 \n",
-      "best model learning rate       :  0.6801747236792569 \n",
-      "best model regularization      :  1.0 \n",
-      "best model num boosting rounds :  32 \n",
-      "elapsed time : 35.21439480781555\n"
+      "best model tree depth          :  5.0 \n",
+      "best model learning rate       :  0.8335521669442962 \n",
+      "best model regularization      :  0.11902468106903752 \n",
+      "best model num boosting rounds :  49 \n",
+      "elapsed time : 145.66159868240356\n"
      ]
     }
    ],
@@ -98,7 +116,20 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "!python main.py --k8s --num_gpus 2 \\\n",
+    "                --num_timesteps 10 --coil_type 'helix'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!python main.py --k8s --adapt --num_gpus 4 --min_gpus 1 \\\n",
+    "                --num_timesteps 10 --coil_type 'helix'"
+   ]
   }
  ],
  "metadata": {

--- a/HPO/main.py
+++ b/HPO/main.py
@@ -34,9 +34,6 @@ spec:
         cpu: "2"
         memory: 6G
         nvidia.com/gpu: 1
-    env:
-      - name: PRE_RUN_HOOK
-        value: "pip install -e git+https://github.com/supertetelman/rapids.git@k8s#egg=rapids&subdirectory=HPO"
 '''
 
 

--- a/HPO/setup.py
+++ b/HPO/setup.py
@@ -1,0 +1,9 @@
+#!/usr/bin/env python
+
+from distutils.core import setup
+
+setup(name='rapids_lib',
+      version='10.0',
+      description='Helper RAPIDS wrapper',
+      py_modules=['rapids_lib_v10'] 
+     )


### PR DESCRIPTION
*Add k8s option to main.py and include examples in the command line notebook. These changes are backwards compatible, If the new flags are not specified LocalCudaCluster is used.

* Added sections to HPO notebook to use k8s cluster if specified and benchmark at 1, 2, and 4 GPUs.

~~* In order for this to work properly in the Dask-workers via the main.py, we need to do a pip -e install of the library files. When we merge this through we should either update the URL being used or consider including the library file and other notebooks in the Docker image used by default~~

